### PR TITLE
Add optional inline autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ FluentTyper is a writing assistant with features such as a spell checker, text e
 As you start typing, FluentTyper will display a pop-up with a list of suggested words, similar to your phone keyboard.
 You can use the arrow keys (↑, ↓) to navigate the list of suggested words, and then press Tab to confirm your selection.
 To hide the list of suggested words, you can either press the Escape key or continue typing.
+Alternatively, FluentTyper can display only the first suggestion inline, similar to Gmail. Enable "Show inline suggestion instead of popup" in the extension settings to try this mode. Use `Tab` to accept the suggestion or `Escape` to dismiss it.
 
 Supported languages:
 - English

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -27,6 +27,7 @@ import {
   KEY_TIME_FORMAT,
   KEY_DATE_FORMAT,
   KEY_USER_DICTIONARY_LIST,
+  KEY_INLINE_AUTOCOMPLETE,
 } from "../shared/constants";
 import { getDomain, isEnabledForDomain, checkLastError } from "../shared/utils";
 import { getErrorMessage } from "../shared/error";
@@ -130,6 +131,7 @@ class BackgroundServiceWorker {
       minWordLengthToPredict,
       revertOnBackspace,
       displayLangHeader,
+      inlineAutocomplete,
     ] = await Promise.all([
       this.settingsManager.get(KEY_ENABLED),
       this.settingsManager.get(KEY_AUTOCOMPLETE),
@@ -139,6 +141,7 @@ class BackgroundServiceWorker {
       this.settingsManager.get(KEY_MIN_WORD_LENGTH_TO_PREDICT),
       this.settingsManager.get(KEY_REVERT_ON_BACKSPACE),
       this.settingsManager.get(KEY_DISPLAY_LANG_HEADER),
+      this.settingsManager.get(KEY_INLINE_AUTOCOMPLETE),
     ]);
     const message: ConfigMessage = {
       command: CMD_BACKGROUND_PAGE_SET_CONFIG,
@@ -152,6 +155,7 @@ class BackgroundServiceWorker {
         minWordLengthToPredict: minWordLengthToPredict as number,
         revertOnBackspace: revertOnBackspace as boolean,
         displayLangHeader: displayLangHeader as boolean,
+        inlineAutocomplete: inlineAutocomplete as boolean,
       },
     };
     return message;

--- a/src/content-script/TributeManager.ts
+++ b/src/content-script/TributeManager.ts
@@ -21,6 +21,8 @@ interface TributeEntry {
   // Store handler references for proper removal
   tributeReplacedHandlerRef?: EventListenerOrEventListenerObject;
   elementKeyDownHandlerRef?: EventListenerOrEventListenerObject;
+  inlineOriginalValue?: string;
+  inlineOriginalSelection?: number | null;
 }
 
 export class TributeManager {
@@ -39,6 +41,12 @@ export class TributeManager {
   private selectByDigit: boolean;
   private revertOnBackspace: boolean;
   private displayLangHeader: boolean;
+  private inlineAutocomplete: boolean;
+  private inlineSuggestions: string[] = [];
+  private inlineIndex: number = 0;
+  private inlineOriginalValue: string = "";
+  private inlineOriginalSelection: number | null = null;
+  private inlineActiveId: number | null = null;
   private reTriggerTributeOnReplaceEvent: boolean = false;
   private activeHelperArrId: number | null = null;
 
@@ -55,6 +63,7 @@ export class TributeManager {
     selectByDigit,
     revertOnBackspace,
     displayLangHeader,
+    inlineAutocomplete,
     // Callbacks to FluentTyper
     getPrediction,
   }: {
@@ -67,6 +76,7 @@ export class TributeManager {
     selectByDigit: boolean;
     revertOnBackspace: boolean;
     displayLangHeader: boolean;
+    inlineAutocomplete: boolean;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     getPrediction: Function;
   }) {
@@ -83,6 +93,7 @@ export class TributeManager {
     this.selectByDigit = selectByDigit;
     this.revertOnBackspace = revertOnBackspace;
     this.displayLangHeader = displayLangHeader;
+    this.inlineAutocomplete = inlineAutocomplete;
     this.getPrediction = getPrediction; // callback to main class
     this.activeHelperArrId = null;
     console.info(
@@ -99,6 +110,7 @@ export class TributeManager {
         selectByDigit,
         revertOnBackspace,
         displayLangHeader,
+        inlineAutocomplete,
       },
     );
   }
@@ -173,6 +185,14 @@ export class TributeManager {
 
       currentEntry.done = done;
       currentEntry.requestId += 1;
+      const elem = currentEntry.elem as HTMLElement;
+      if (elem instanceof HTMLInputElement || elem instanceof HTMLTextAreaElement) {
+        currentEntry.inlineOriginalValue = elem.value;
+        currentEntry.inlineOriginalSelection = elem.selectionStart;
+      } else {
+        currentEntry.inlineOriginalValue = elem.textContent || "";
+        currentEntry.inlineOriginalSelection = this.getCaretOffset(elem);
+      }
       this.activeHelperArrId = tributeId;
 
       console.info(
@@ -247,7 +267,7 @@ export class TributeManager {
       { leading: false, trailing: true },
     );
     const boundElementKeyDownHandler = debounce(
-      this.elementKeyDownEventHandler.bind(this, tributeId),
+      (event: KeyboardEvent) => this.elementKeyDownEventHandler(tributeId, event),
       32,
     );
     // @ts-expect-error ignore Tribute errors
@@ -296,7 +316,18 @@ export class TributeManager {
           header,
         },
       );
-      tributeEntry.done(keyValPairs, context.forceReplace, header);
+      if (this.inlineAutocomplete) {
+        this.inlineSuggestions = context.predictions;
+        this.inlineIndex = 0;
+        this.inlineActiveId = context.tributeId;
+        this.inlineOriginalValue =
+          tributeEntry.inlineOriginalValue ?? (tributeEntry.elem as HTMLInputElement).value;
+        this.inlineOriginalSelection =
+          tributeEntry.inlineOriginalSelection ?? null;
+        this.applyInlineSuggestion();
+      } else {
+        tributeEntry.done(keyValPairs, context.forceReplace, header);
+      }
     } else {
       console.warn(
         "[%s:%s:%s] fulfillPrediction: No matching tributeEntry or requestId mismatch",
@@ -308,10 +339,104 @@ export class TributeManager {
     }
   }
 
+  private clearInlineSuggestion() {
+    this.inlineSuggestions = [];
+    this.inlineIndex = 0;
+    this.inlineActiveId = null;
+  }
+
+  private getCaretOffset(elem: HTMLElement): number {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      return (elem.textContent || "").length;
+    }
+    const range = selection.getRangeAt(0);
+    if (!elem.contains(range.startContainer)) {
+      return (elem.textContent || "").length;
+    }
+    const preRange = range.cloneRange();
+    preRange.selectNodeContents(elem);
+    preRange.setEnd(range.startContainer, range.startOffset);
+    return preRange.toString().length;
+  }
+
+  private setCaretRange(elem: HTMLElement, start: number, end: number) {
+    const selection = window.getSelection();
+    if (!selection) return;
+    const range = document.createRange();
+    if (!elem.firstChild) {
+      elem.appendChild(document.createTextNode(""));
+    }
+    const node = elem.firstChild as Text;
+    range.setStart(node, Math.min(start, node.length));
+    range.setEnd(node, Math.min(end, node.length));
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  private applyInlineSuggestion() {
+    if (this.inlineActiveId === null) return;
+    const entry = this.tributeArr[this.inlineActiveId];
+    if (!entry) return;
+    const elem = entry.elem as HTMLElement;
+    const prefix = this.inlineOriginalValue.slice(0, this.inlineOriginalSelection ?? 0);
+    const suffix = this.inlineOriginalValue.slice(this.inlineOriginalSelection ?? 0);
+    const suggestion = this.inlineSuggestions[this.inlineIndex] || "";
+    const newText = prefix + suggestion + suffix;
+    if (elem instanceof HTMLInputElement || elem instanceof HTMLTextAreaElement) {
+      elem.value = newText;
+      const start = prefix.length;
+      elem.setSelectionRange(start, start + suggestion.length);
+    } else {
+      elem.textContent = newText;
+      this.setCaretRange(elem, prefix.length, prefix.length + suggestion.length);
+    }
+  }
+
+  private acceptInlineSuggestion() {
+    if (this.inlineActiveId === null) return;
+    const entry = this.tributeArr[this.inlineActiveId];
+    if (!entry) return;
+    const elem = entry.elem as HTMLElement;
+    const prefix = this.inlineOriginalValue.slice(0, this.inlineOriginalSelection ?? 0);
+    const suggestion = this.inlineSuggestions[this.inlineIndex] || "";
+    const suffix = this.inlineOriginalValue.slice(this.inlineOriginalSelection ?? 0);
+    const newText = prefix + suggestion + suffix;
+    if (elem instanceof HTMLInputElement || elem instanceof HTMLTextAreaElement) {
+      elem.value = newText;
+      const caret = (prefix + suggestion).length;
+      elem.setSelectionRange(caret, caret);
+    } else {
+      elem.textContent = newText;
+      this.setCaretRange(elem, (prefix + suggestion).length, (prefix + suggestion).length);
+    }
+    this.clearInlineSuggestion();
+  }
+
+  private cancelInlineSuggestion() {
+    if (this.inlineActiveId === null) return;
+    const entry = this.tributeArr[this.inlineActiveId];
+    if (!entry) return;
+    const elem = entry.elem as HTMLElement;
+    if (elem instanceof HTMLInputElement || elem instanceof HTMLTextAreaElement) {
+      elem.value = this.inlineOriginalValue;
+      const caret = this.inlineOriginalSelection ?? this.inlineOriginalValue.length;
+      elem.setSelectionRange(caret, caret);
+    } else {
+      elem.textContent = this.inlineOriginalValue;
+      const caret = this.inlineOriginalSelection ?? this.inlineOriginalValue.length;
+      this.setCaretRange(elem, caret, caret);
+    }
+    this.clearInlineSuggestion();
+  }
+
   detachHelper(tributeId: number) {
     const entry = this.tributeArr[tributeId];
     if (!entry) return;
     const elem = entry.elem;
+    if (this.inlineActiveId === tributeId) {
+      this.clearInlineSuggestion();
+    }
     entry.tribute.detach(elem);
     if (entry.tributeReplacedHandlerRef) {
       elem.removeEventListener(
@@ -330,6 +455,7 @@ export class TributeManager {
       this.detachHelper(Number(key));
     }
     this.tributeArr = {};
+    this.clearInlineSuggestion();
   }
 
   isHelperAttached(elem: Element) {
@@ -479,8 +605,29 @@ export class TributeManager {
     }
   }
 
-  elementKeyDownEventHandler(helperArrId: number) {
+  elementKeyDownEventHandler(helperArrId: number, event: KeyboardEvent) {
     this.activeHelperArrId = helperArrId;
+    if (this.inlineAutocomplete && this.inlineActiveId === helperArrId && this.inlineSuggestions.length > 0) {
+      if (event.key === "Tab") {
+        event.preventDefault();
+        this.acceptInlineSuggestion();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        this.cancelInlineSuggestion();
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        this.inlineIndex = (this.inlineIndex + 1) % this.inlineSuggestions.length;
+        this.applyInlineSuggestion();
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        this.inlineIndex = (this.inlineIndex - 1 + this.inlineSuggestions.length) % this.inlineSuggestions.length;
+        this.applyInlineSuggestion();
+      } else if (event.key === "Backspace") {
+        this.cancelInlineSuggestion();
+      } else if (event.key.length === 1) {
+        this.clearInlineSuggestion();
+      }
+    }
   }
 
   updateLangConfig(lang: string) {

--- a/src/content-script/content_script.ts
+++ b/src/content-script/content_script.ts
@@ -53,6 +53,7 @@ class FluentTyper {
     minWordLengthToPredict: 0,
     revertOnBackspace: true,
     displayLangHeader: true,
+    inlineAutocomplete: false,
   };
   public domObserver: DomObserver;
   private hostName: string = window.location.hostname;
@@ -187,6 +188,7 @@ class FluentTyper {
       selectByDigit: this.config.selectByDigit,
       revertOnBackspace: this.config.revertOnBackspace,
       displayLangHeader: this.config.displayLangHeader,
+      inlineAutocomplete: this.config.inlineAutocomplete,
       getPrediction: this.handleGetPrediction.bind(this),
     });
     // Set autocompleteSeparator property after construction

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,6 +38,7 @@ export const KEY_LANGUAGE = "language";
 export const KEY_FALLBACK_LANGUAGE = "fallbackLanguage";
 export const KEY_DOMAIN_LIST_MODE = "domainListMode";
 export const KEY_DISPLAY_LANG_HEADER = "displayLangHeader";
+export const KEY_INLINE_AUTOCOMPLETE = "inlineAutocomplete";
 export const KEY_ENABLED = "enabled";
 
 // Popup Commands

--- a/src/shared/messageTypes.ts
+++ b/src/shared/messageTypes.ts
@@ -9,6 +9,7 @@ export interface SetConfigContext {
   revertOnBackspace: boolean;
   enabled: boolean;
   displayLangHeader: boolean;
+  inlineAutocomplete: boolean;
 }
 
 // Context for CMD_BACKGROUND_PAGE_PREDICT_REQ

--- a/src/third_party/fancier-settings/manifest.js
+++ b/src/third_party/fancier-settings/manifest.js
@@ -11,6 +11,7 @@ import {
   KEY_AUTO_CAPITALIZE,
   KEY_SELECT_BY_DIGIT,
   KEY_REVERT_ON_BACKSPACE,
+  KEY_INLINE_AUTOCOMPLETE,
   KEY_LANGUAGE,
   KEY_FALLBACK_LANGUAGE,
   KEY_MIN_WORD_LENGTH_TO_PREDICT,
@@ -123,6 +124,14 @@ const manifest = {
       name: KEY_REVERT_ON_BACKSPACE,
       type: "checkbox",
       label: i18n.get("Enable Smart Backspace") + ":&nbsp;<small>" + i18n.get("When enabled, Backspace will undo the last auto-completion. When disabled, it deletes one character at a time.") + "</small>",
+      default: false,
+    },
+    {
+      tab: i18n.get("Autocomplete"),
+      group: i18n.get("Behavior After Completion"),
+      name: KEY_INLINE_AUTOCOMPLETE,
+      type: "checkbox",
+      label: i18n.get("Show inline suggestion instead of popup"),
       default: false,
     },
 

--- a/src/third_party/fancier-settings/settings.js
+++ b/src/third_party/fancier-settings/settings.js
@@ -19,6 +19,7 @@ import {
   KEY_TIME_FORMAT,
   KEY_DATE_FORMAT,
   KEY_REVERT_ON_BACKSPACE,
+  KEY_INLINE_AUTOCOMPLETE,
   KEY_TEXT_EXPANSIONS,
   KEY_USER_DICTIONARY_LIST,
   KEY_DOMAIN_LIST_MODE,
@@ -217,7 +218,8 @@ window.addEventListener("DOMContentLoaded", function () {
         KEY_REVERT_ON_BACKSPACE,
         KEY_TEXT_EXPANSIONS,
         KEY_USER_DICTIONARY_LIST,
-        KEY_DISPLAY_LANG_HEADER
+        KEY_DISPLAY_LANG_HEADER,
+        KEY_INLINE_AUTOCOMPLETE
       ].forEach((element) => {
         settings.manifest[element].addEvent("action", function () {
           optionsPageConfigChange();


### PR DESCRIPTION
## Summary
- add KEY_INLINE_AUTOCOMPLETE constant and wire through config
- implement inline suggestion logic in TributeManager
- expose new setting via options manifest
- fix inline autocomplete for contentEditable fields
- document the new setting in README

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6871eb0e22ac8330a69d4d11b0c936c2